### PR TITLE
fix: terminate background thread when widget closes

### DIFF
--- a/rqt_chat/chat.py
+++ b/rqt_chat/chat.py
@@ -28,3 +28,6 @@ class ChatPlugin(Plugin):
 
         self._widget = ChatWidget(self._node, self)
         context.add_widget(self._widget)
+
+    def shutdown_plugin(self):
+        self._widget.close()

--- a/rqt_chat/chat_widget.py
+++ b/rqt_chat/chat_widget.py
@@ -171,5 +171,6 @@ class ChatWidget(QWidget):
     def closeEvent(self, event):
         # Clean up background thread
         self.update_thread_running = False
+        self.msgQueue.put(AsyncMsg(type="Robot"))
         self.update_thread.join()
         super(ChatWidget, self).closeEvent(event)

--- a/rqt_chat/main.py
+++ b/rqt_chat/main.py
@@ -1,0 +1,12 @@
+import sys
+
+from rqt_gui.main import Main
+
+
+def main():
+    main = Main()
+    sys.exit(main.main(sys.argv, standalone="rqt_chat.chat.ChatPlugin"))
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
+            'rqt_chat = ' + package_name + '.main:main',
         ],
     },
 )


### PR DESCRIPTION
When the widget is closed, or when rqt is closed, the background thread in `ChatWidget` is not stopped, and the terminal hangs. After some testing, it looks like `ChatWidget.closeEvent` is not called.

I edited `chat.py` to act on `shutdown_plugin` as in https://github.com/ros-visualization/rqt_plot/blob/rolling/src/rqt_plot/plot.py, and manually close the widget with `.close()`. An extra fake event is put in the `msgQueue` to unblock the thread waiting on `.get()` when the queue is empty.

This was tested manually with `rqt --force-discover --clear-config`.